### PR TITLE
Scaffold TabView with placeholder views

### DIFF
--- a/AdminView.swift
+++ b/AdminView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct AdminView: View {
+    var body: some View {
+        Text("Admin View Placeholder")
+            .padding()
+    }
+}
+
+#Preview {
+    AdminView()
+}

--- a/HomeView.swift
+++ b/HomeView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("Home View Placeholder")
+            .padding()
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/LunchManagerApp.swift
+++ b/LunchManagerApp.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct LunchManagerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            TabView {
+                HomeView()
+                    .tabItem {
+                        Label("Home", systemImage: "house")
+                    }
+
+                AdminView()
+                    .tabItem {
+                        Label("Admin", systemImage: "wrench.and.screwdriver")
+                    }
+
+                SettingsView()
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                    }
+            }
+            .modelContainer(for: [])
+        }
+    }
+}
+

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("Settings View Placeholder")
+            .padding()
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## Summary
- add `LunchManagerApp` using SwiftUI and SwiftData
- scaffold TabView with Home, Admin, and Settings tabs
- create placeholder views for each tab

## Testing
- `swiftc LunchManagerApp.swift HomeView.swift AdminView.swift SettingsView.swift -o LunchManager` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ab9844afc4832086bd20a77b1b21f4