### PR TITLE
Add SwiftData models for lunch planning with seed data

### DIFF
--- a/Models/LunchModels.swift
+++ b/Models/LunchModels.swift
@@ -1,0 +1,112 @@
+import Foundation
+import SwiftData
+
+enum PrepTiming: String, Codable, CaseIterable {
+    case nightBefore
+    case morningOf
+
+    var label: String {
+        switch self {
+        case .nightBefore:
+            return "Night Before"
+        case .morningOf:
+            return "Morning Of"
+        }
+    }
+}
+
+@Model
+final class LunchPlan {
+    @Attribute(.unique) var id: UUID
+    var date: Date
+    var main: String
+    var sides: [String]
+    var drink: String?
+    var notes: String?
+    @Relationship(deleteRule: .cascade, inverse: \PrepStep.plan) var steps: [PrepStep]
+
+    init(
+        id: UUID = UUID(),
+        date: Date,
+        main: String,
+        sides: [String],
+        drink: String? = nil,
+        notes: String? = nil,
+        steps: [PrepStep] = []
+    ) {
+        self.id = id
+        self.date = date.startOfDay()
+        self.main = main
+        self.sides = sides
+        self.drink = drink
+        self.notes = notes
+        self.steps = steps
+    }
+}
+
+@Model
+final class PrepStep {
+    @Attribute(.unique) var id: UUID
+    var text: String
+    var timing: PrepTiming
+    @Relationship(inverse: \LunchPlan.steps) var plan: LunchPlan?
+
+    init(
+        id: UUID = UUID(),
+        text: String,
+        timing: PrepTiming,
+        plan: LunchPlan? = nil
+    ) {
+        self.id = id
+        self.text = text
+        self.timing = timing
+        self.plan = plan
+    }
+}
+
+extension Date {
+    func startOfDay() -> Date {
+        Calendar.current.startOfDay(for: self)
+    }
+
+    func tomorrow() -> Date {
+        Calendar.current.date(byAdding: .day, value: 1, to: startOfDay())!
+    }
+
+    var yyyyMMddString: String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar.current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Calendar.current.timeZone
+        formatter.dateFormat = "yyyyMMdd"
+        return formatter.string(from: self)
+    }
+}
+
+enum SeedData {
+    static func ensureSeed(container: ModelContainer) {
+        let context = ModelContext(container)
+
+        let fetch = FetchDescriptor<LunchPlan>()
+        if (try? context.fetch(fetch))?.isEmpty == true {
+            let tomorrow = Date().tomorrow()
+            let plan = LunchPlan(
+                date: tomorrow,
+                main: "Sandwich",
+                sides: ["Chips", "Fruit"],
+                drink: "Water",
+                notes: "Pack utensils"
+            )
+
+            let step1 = PrepStep(text: "Prepare ingredients", timing: .nightBefore, plan: plan)
+            let step2 = PrepStep(text: "Assemble sandwich", timing: .morningOf, plan: plan)
+            let step3 = PrepStep(text: "Pack lunch bag", timing: .morningOf, plan: plan)
+
+            plan.steps = [step1, step2, step3]
+
+            context.insert(plan)
+            try? context.save()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PrepTiming enum and SwiftData models LunchPlan and PrepStep with cascade relationship
- add Date convenience helpers
- add SeedData.ensureSeed to preload sample plan with prep steps

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9b32de448320b0be7035d69f539a