### PR TITLE
Initialize model container and seed sample data

### DIFF
--- a/LunchManagerApp.swift
+++ b/LunchManagerApp.swift
@@ -3,6 +3,20 @@ import SwiftData
 
 @main
 struct LunchManagerApp: App {
+    @AppStorage("hasSeeded") private var hasSeeded = false
+
+    var sharedModelContainer: ModelContainer = {
+        let container = try! ModelContainer(for: [LunchPlan.self, PrepStep.self])
+        return container
+    }()
+
+    init() {
+        if !hasSeeded {
+            SeedData.ensureSeed(container: sharedModelContainer)
+            hasSeeded = true
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             TabView {
@@ -21,8 +35,8 @@ struct LunchManagerApp: App {
                         Label("Settings", systemImage: "gearshape")
                     }
             }
-            .modelContainer(for: [])
         }
+        .modelContainer(sharedModelContainer)
     }
 }
 


### PR DESCRIPTION
## Summary
- Initialize `ModelContainer` for `LunchPlan` and `PrepStep`
- Seed sample data on first launch via `SeedData.ensureSeed`
- Present `TabView` with Home, Admin, and Settings screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bd9f58083209a4a2dd75e1f6f00