### PR TITLE
Implement lunch plan admin list and editor

### DIFF
--- a/AdminView.swift
+++ b/AdminView.swift
@@ -1,9 +1,50 @@
 import SwiftUI
+import SwiftData
 
 struct AdminView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: [SortDescriptor(\LunchPlan.date, order: .reverse)]) private var plans: [LunchPlan]
+    @State private var isAdding = false
+
     var body: some View {
-        Text("Admin View Placeholder")
-            .padding()
+        NavigationStack {
+            List {
+                ForEach(plans) { plan in
+                    NavigationLink {
+                        PlanEditorView(plan: plan)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(plan.date, style: .date)
+                                .font(.headline)
+                            Text(plan.main)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+                .onDelete(perform: deletePlans)
+            }
+            .navigationTitle("Plans")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        isAdding = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $isAdding) {
+                PlanEditorView(plan: nil)
+            }
+        }
+    }
+
+    private func deletePlans(at offsets: IndexSet) {
+        for index in offsets {
+            let plan = plans[index]
+            context.delete(plan)
+        }
+        try? context.save()
     }
 }
 

--- a/PlanEditorView.swift
+++ b/PlanEditorView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import SwiftData
+
+struct PlanEditorView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    private var plan: LunchPlan?
+    @State private var date: Date
+    @State private var main: String
+    private var isNew: Bool
+
+    init(plan: LunchPlan?) {
+        self.plan = plan
+        _date = State(initialValue: plan?.date ?? Date())
+        _main = State(initialValue: plan?.main ?? "")
+        self.isNew = plan == nil
+    }
+
+    var body: some View {
+        Form {
+            DatePicker("Date", selection: $date, displayedComponents: .date)
+            TextField("Main Dish", text: $main)
+        }
+        .navigationTitle(isNew ? "New Plan" : "Edit Plan")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+            }
+        }
+    }
+
+    private func save() {
+        if let plan {
+            plan.date = date.startOfDay()
+            plan.main = main
+        } else {
+            let newPlan = LunchPlan(date: date, main: main, sides: [])
+            context.insert(newPlan)
+        }
+        try? context.save()
+        dismiss()
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PlanEditorView(plan: nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Show lunch plans sorted by date with delete and navigation
- Add a toolbar button to create new plans
- Introduce PlanEditorView for creating and editing plans

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9cdf06b08320be3ae39d5d940229