### PR TITLE
Add UI helpers and style HomeView

### DIFF
--- a/Helpers/UIHelpers.swift
+++ b/Helpers/UIHelpers.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+// Capsule-style pill view for displaying side items
+struct Pill: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(Color.gray.opacity(0.2))
+            )
+    }
+}
+
+// Returns a color for section headers based on the prep timing
+func sectionHeaderColor(for timing: PrepTiming) -> Color {
+    switch timing {
+    case .nightBefore:
+        return .purple
+    case .morningOf:
+        return .yellow
+    }
+}
+
+// Date formatting helper
+extension Date {
+    /// Formats date like "Tue, Jul 16"
+    var weekdayMonthDay: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, MMM d"
+        return formatter.string(from: self)
+    }
+}
+

--- a/HomeView.swift
+++ b/HomeView.swift
@@ -1,12 +1,74 @@
 import SwiftUI
+import SwiftData
 
 struct HomeView: View {
+    @Query(sort: \LunchPlan.date, order: .forward, limit: 1)
+    private var plans: [LunchPlan]
+
     var body: some View {
-        Text("Home View Placeholder")
-            .padding()
+        if let plan = plans.first {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(plan.date.weekdayMonthDay)
+                        .font(.title2)
+                        .bold()
+                        .accessibilityLabel("Lunch plan for \(plan.date.weekdayMonthDay)")
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(plan.main)
+                            .font(.headline)
+
+                        if !plan.sides.isEmpty {
+                            HStack {
+                                ForEach(plan.sides, id: \.self) { side in
+                                    Pill(text: side)
+                                }
+                            }
+                        }
+
+                        if let drink = plan.drink {
+                            Text("Drink: \(drink)")
+                                .font(.subheadline)
+                        }
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(.systemBackground))
+                    )
+                    .shadow(radius: 2)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Main \(plan.main), sides \(plan.sides.joined(separator: ", ")), drink \(plan.drink ?? \"None\")")
+
+                    ForEach(PrepTiming.allCases, id: \.self) { timing in
+                        let steps = plan.steps.filter { $0.timing == timing }
+                        if !steps.isEmpty {
+                            Section {
+                                ForEach(steps, id: \.id) { step in
+                                    Text(step.text)
+                                        .padding(.vertical, 4)
+                                }
+                            } header: {
+                                Text(timing.label)
+                                    .font(.headline)
+                                    .foregroundColor(sectionHeaderColor(for: timing))
+                            }
+                        }
+                    }
+
+                    Spacer()
+                }
+                .padding()
+            }
+        } else {
+            Text("No plan available")
+                .padding()
+        }
     }
 }
 
 #Preview {
     HomeView()
+        .modelContainer(for: [LunchPlan.self, PrepStep.self], inMemory: true)
 }
+


### PR DESCRIPTION
## Summary
- introduce `UIHelpers` with pill view, header colors, and date formatting
- style `HomeView` using helpers with rounded cards and accessibility labels

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9d1b7774832096e2651b8edb4dc2