### PR TITLE
Add UI helpers and style HomeView

### DIFF
--- a/Helpers/UIHelpers.swift
+++ b/Helpers/UIHelpers.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct Pill: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(
+                Capsule()
+                    .fill(Color.accentColor.opacity(0.2))
+            )
+            .accessibilityLabel(text)
+    }
+}
+
+func sectionHeaderColor(for timing: PrepTiming) -> Color {
+    switch timing {
+    case .nightBefore:
+        return .purple
+    case .morningOf:
+        return .yellow
+    }
+}
+
+private let weekdayMonthDayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "EEE MMM d"
+    return formatter
+}()
+
+extension Date {
+    func weekdayMonthDay() -> String {
+        weekdayMonthDayFormatter.string(from: self)
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable UI helpers including Pill view, prep section color mapping, and weekday/month-day formatter
- restyle HomeView to use helpers with rounded cards, shadows, spacing, and accessibility labels

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9e2ac48c83209b3e934390cb11db