### PR TITLE
Add in-memory SwiftData previews for key views

### DIFF
--- a/AdminView.swift
+++ b/AdminView.swift
@@ -49,5 +49,11 @@ struct AdminView: View {
 }
 
 #Preview {
-    AdminView()
+    let container = try! ModelContainer(
+        for: [LunchPlan.self, PrepStep.self],
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+    SeedData.ensureSeed(container: container)
+    return AdminView()
+        .modelContainer(container)
 }

--- a/HomeView.swift
+++ b/HomeView.swift
@@ -121,5 +121,11 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView()
+    let container = try! ModelContainer(
+        for: [LunchPlan.self, PrepStep.self],
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+    SeedData.ensureSeed(container: container)
+    return HomeView()
+        .modelContainer(container)
 }

--- a/PlanEditorView.swift
+++ b/PlanEditorView.swift
@@ -47,7 +47,15 @@ struct PlanEditorView: View {
 }
 
 #Preview {
-    NavigationStack {
-        PlanEditorView(plan: nil)
+    let container = try! ModelContainer(
+        for: [LunchPlan.self, PrepStep.self],
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+    SeedData.ensureSeed(container: container)
+    let context = ModelContext(container)
+    let plan = try? context.fetch(FetchDescriptor<LunchPlan>()).first
+    return NavigationStack {
+        PlanEditorView(plan: plan)
     }
+    .modelContainer(container)
 }


### PR DESCRIPTION
## Summary
- add in-memory seeded ModelContainer previews for HomeView
- add AdminView preview with ephemeral container and seed data
- add PlanEditorView preview seeded and editing first plan

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9f57d2f8832091629bf0c62d5985