### PR TITLE
Support macOS system background colors

### DIFF
--- a/Sources/LunchManager/HomeView.swift
+++ b/Sources/LunchManager/HomeView.swift
@@ -77,7 +77,13 @@ struct HomeView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(Color(uiColor: .systemBackground))
+                .fill(
+                    #if os(iOS)
+                    Color(.systemBackground)
+                    #elseif os(macOS)
+                    Color(nsColor: .windowBackgroundColor)
+                    #endif
+                )
         )
         .shadow(radius: 1)
     }
@@ -113,7 +119,13 @@ struct HomeView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 16)
-                    .fill(Color(uiColor: .systemBackground))
+                    .fill(
+                        #if os(iOS)
+                        Color(.systemBackground)
+                        #elseif os(macOS)
+                        Color(nsColor: .windowBackgroundColor)
+                        #endif
+                    )
             )
             .shadow(radius: 1)
         }


### PR DESCRIPTION
## Summary
- Use platform-specific system background colors in `HomeView` for iOS and macOS

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68aba710c0588320b80e11c2ab561264