### PR TITLE
Improve context error handling

### DIFF
--- a/Sources/LunchManager/Models/LunchModels.swift
+++ b/Sources/LunchManager/Models/LunchModels.swift
@@ -88,24 +88,33 @@ enum SeedData {
         let context = ModelContext(container)
 
         let fetch = FetchDescriptor<LunchPlan>()
-        if (try? context.fetch(fetch))?.isEmpty == true {
-            let tomorrow = Date().tomorrow()
-            let plan = LunchPlan(
-                date: tomorrow,
-                main: "Sandwich",
-                sides: ["Chips", "Fruit"],
-                drink: "Water",
-                notes: "Pack utensils"
-            )
+        do {
+            let plans = try context.fetch(fetch)
+            if plans.isEmpty {
+                let tomorrow = Date().tomorrow()
+                let plan = LunchPlan(
+                    date: tomorrow,
+                    main: "Sandwich",
+                    sides: ["Chips", "Fruit"],
+                    drink: "Water",
+                    notes: "Pack utensils"
+                )
 
-            let step1 = PrepStep(text: "Prepare ingredients", timing: .nightBefore, plan: plan)
-            let step2 = PrepStep(text: "Assemble sandwich", timing: .morningOf, plan: plan)
-            let step3 = PrepStep(text: "Pack lunch bag", timing: .morningOf, plan: plan)
+                let step1 = PrepStep(text: "Prepare ingredients", timing: .nightBefore, plan: plan)
+                let step2 = PrepStep(text: "Assemble sandwich", timing: .morningOf, plan: plan)
+                let step3 = PrepStep(text: "Pack lunch bag", timing: .morningOf, plan: plan)
 
-            plan.steps = [step1, step2, step3]
+                plan.steps = [step1, step2, step3]
 
-            context.insert(plan)
-            try? context.save()
+                context.insert(plan)
+                do {
+                    try context.save()
+                } catch {
+                    print("Failed to seed data: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            print("Failed to fetch lunch plans for seeding: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/LunchManager/Views/PlanEditorView.swift
+++ b/Sources/LunchManager/Views/PlanEditorView.swift
@@ -7,6 +7,8 @@ struct PlanEditorView: View {
 
     @Bindable var plan: LunchPlan
     @State private var sidesText: String
+    @State private var saveErrorMessage = ""
+    @State private var isSaveErrorPresented = false
 
     init(plan: LunchPlan) {
         self._plan = Bindable(wrappedValue: plan)
@@ -107,6 +109,11 @@ struct PlanEditorView: View {
                     .disabled(plan.main.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
+        .alert("Failed to Save", isPresented: $isSaveErrorPresented, actions: {
+            Button("OK", role: .cancel) {}
+        }, message: {
+            Text(saveErrorMessage)
+        })
     }
 
     private func addStep(timing: PrepTiming) {
@@ -131,8 +138,13 @@ struct PlanEditorView: View {
         if plan.modelContext == nil {
             context.insert(plan)
         }
-        try? context.save()
-        dismiss()
+        do {
+            try context.save()
+            dismiss()
+        } catch {
+            saveErrorMessage = error.localizedDescription
+            isSaveErrorPresented = true
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap seed data fetch/save in do-catch blocks with logging
- Present alert when plan save fails and handle errors

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68aba7e421c88320976db934c29e5b35